### PR TITLE
feat: add git subtree to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add git docker bash --no-cache && rm -rf /var/cache/apk/*
+RUN apk add git git-subtree docker bash --no-cache && rm -rf /var/cache/apk/*
 
 RUN npm install -g semantic-release@^15.13.24 @semantic-release/npm@^5.1.15 @semantic-release/git@^7.0.16 @semantic-release/github@^5.4.3 @semantic-release/changelog@^3.0.4
 


### PR DESCRIPTION
git subtree is useful when I want to publish a subdirectory as a subtree during a release

fixes #4 